### PR TITLE
Redirect após login para página de navegação funcionando

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -475,7 +475,7 @@ class Provider extends \MapasCulturais\AuthProvider{
      * @param string $redirect_path
      */
     protected function _setRedirectPath($redirect_path){
-        $_SESSION['mapasculturais.auth.redirect_path'] = $redirect_path;
+        parent::_setRedirectPath($redirect_path);
     }
     /**
      * Returns the URL to redirect after authentication


### PR DESCRIPTION
Pequena alteração no método para utilizar a classe pai e redirecionar corretamente o usuário para a página em que estava navegando até o momento do login